### PR TITLE
docs: Sharp is now optional — install guide + troubleshooting

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -107,6 +107,13 @@ npm start</code></pre>
 
       <p>All dependencies are pulled in by npm. No native compilation required for the core app.</p>
 
+      <div class="callout">
+        <strong>📦 Optional: Image Compression</strong>
+        <p style="margin-top: 8px; margin-bottom: 0;">Uplink can use <a href="https://sharp.pixelplumbing.com" target="_blank">Sharp</a> to automatically compress uploaded images before sending them to the AI. Sharp is optional — if it's not installed, images are sent at their original size. To enable compression:</p>
+        <pre style="margin-top: 8px; margin-bottom: 0;"><code>npm install sharp</code></pre>
+        <p style="margin-top: 8px; margin-bottom: 0;">If Sharp fails to install (common on some systems without build tools), don't worry — everything else works fine without it.</p>
+      </div>
+
       <p>You'll see output like:</p>
 
       <div class="code-block">

--- a/troubleshooting.html
+++ b/troubleshooting.html
@@ -93,6 +93,16 @@ rm -rf node_modules
 npm install</code></pre>
       </div>
 
+      <h3>Sharp Install Fails</h3>
+      <p><a href="https://sharp.pixelplumbing.com" target="_blank">Sharp</a> is an optional dependency used for image compression. If it fails to install with native build errors, that's OK — Uplink works fine without it. Images will just be sent at their original size.</p>
+      <p>If you want image compression and Sharp won't install:</p>
+      <ul>
+        <li><strong>macOS:</strong> <code>xcode-select --install</code> to get build tools, then retry <code>npm install sharp</code></li>
+        <li><strong>Windows:</strong> Install <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/" target="_blank">Visual C++ Build Tools</a>, then retry</li>
+        <li><strong>Linux / WSL2:</strong> <code>sudo apt install build-essential</code>, then retry</li>
+        <li><strong>Still failing:</strong> Skip it. Everything else works without Sharp.</li>
+      </ul>
+
       <h2>Messages Not Working</h2>
 
       <h3>Gateway Connection Failed</h3>


### PR DESCRIPTION
## What

Sharp was moved to optionalDependencies in Uplink PR #131. Docs need to reflect this.

### Changes

**getting-started.html**
- Added callout explaining Sharp is optional for image compression
- Shows how to install it separately if wanted
- Reassures users that everything works without it

**troubleshooting.html**  
- Added Sharp troubleshooting section with platform-specific fix instructions (macOS, Windows, Linux/WSL2)
- Clear message: skip it if it won't install, nothing breaks